### PR TITLE
Separate game info and events messages

### DIFF
--- a/client/engine/event_handler.py
+++ b/client/engine/event_handler.py
@@ -34,7 +34,8 @@ from .commands import (
     SetProfile,
 )
 from common.messages import (
-    GameMessage,
+    GameInfoMessage,
+    GameEventsMessage,
     ErrorMessage,
     GetGameStatus,
     CreateAGameMessage,
@@ -127,7 +128,7 @@ class RefreshGameStatusNetworkRequestEventHandler(EventHandler):
 
         response = Channel.send_command(request_data)
         if response is not None:
-            if isinstance(response, GameMessage):
+            if isinstance(response, GameEventsMessage):
                 UpdateGame(
                     client_state.profile, client_state.queue, response.events
                 ).execute()
@@ -148,7 +149,7 @@ class CreateAGameNetworkRequestEventHandler(EventHandler):
 
         response = Channel.send_command(request_data)
         if response is not None:
-            if isinstance(response, GameMessage):
+            if isinstance(response, GameInfoMessage):
                 InitiateGame(
                     client_state.profile,
                     client_state.queue,
@@ -182,7 +183,7 @@ class JoinAGameNetworkRequestEventHandler(EventHandler):
 
         response = Channel.send_command(request_data)
         if response is not None:
-            if isinstance(response, GameMessage):
+            if isinstance(response, GameInfoMessage):
                 InitiateGame(
                     client_state.profile,
                     client_state.queue,

--- a/client/engine/tests/test_client.py
+++ b/client/engine/tests/test_client.py
@@ -39,7 +39,12 @@ from client.engine.commands import (
     ChatMessageInGameCommand,
     UpdateGameList,
 )
-from common.messages import GameMessage, PingResponseMessage, PingRequestMessage
+from common.messages import (
+    GameInfoMessage,
+    GameEventsMessage,
+    PingResponseMessage,
+    PingRequestMessage,
+)
 from client.engine.game_data import GameData
 import mock
 
@@ -194,7 +199,7 @@ class TestClient(TestCase):
     def test_request_game_status_success(self, m_send_command):
 
         # The server will respond with a correct game message
-        m_send_command.return_value = GameMessage(
+        m_send_command.return_value = GameEventsMessage(
             GameData(
                 "game_id",
                 "game_name",
@@ -241,7 +246,7 @@ class TestClient(TestCase):
 
     @mock.patch("client.engine.event_handler.Channel.send_command")
     def test_request_create_new_game_success(self, m_send_command):
-        m_send_command.return_value = GameMessage(
+        m_send_command.return_value = GameInfoMessage(
             GameData(
                 "game_id",
                 "game_name",
@@ -293,7 +298,7 @@ class TestClient(TestCase):
 
     @mock.patch("client.engine.event_handler.Channel.send_command")
     def test_request_join_a_game_success(self, m_send_command):
-        m_send_command.return_value = GameMessage(
+        m_send_command.return_value = GameInfoMessage(
             GameData(
                 "game_id",
                 "game_name",

--- a/client/game/event_handler.py
+++ b/client/game/event_handler.py
@@ -1,6 +1,6 @@
 from client.engine.primitives.event_handler import EventHandler
 from common.messages import (
-    GameMessage,
+    GameEventsMessage,
     ErrorMessage,
     PlaceASymbolMessage,
     SendChatMessage,
@@ -200,7 +200,7 @@ class PlaceASymbolNetworkRequestEventHandler(EventHandler):
 
         response = Channel.send_command(request_data)
         if response is not None:
-            if isinstance(response, GameMessage):
+            if isinstance(response, GameEventsMessage):
                 UpdateGame(
                     client_state.profile, client_state.queue, response.events
                 ).execute()
@@ -222,7 +222,7 @@ class SendChatNetworkRequestEventHandler(EventHandler):
 
         response = Channel.send_command(request_data)
         if response is not None:
-            if isinstance(response, GameMessage):
+            if isinstance(response, GameEventsMessage):
                 UpdateGame(
                     client_state.profile, client_state.queue, response.events
                 ).execute()

--- a/common/messages.py
+++ b/common/messages.py
@@ -1,8 +1,12 @@
-class GameMessage:
+class GameInfoMessage:
     def __init__(self, game):
         self.id = game.id
         self.name = game.name
         self.players = game.players
+
+
+class GameEventsMessage:
+    def __init__(self, game):
         self.events = game.events  # TODO: This could be too big for the channel
 
 

--- a/common/messages.py
+++ b/common/messages.py
@@ -3,12 +3,12 @@ class GameMessage:
         self.id = game.id
         self.name = game.name
         self.players = game.players
-        self.events = game.events
+        self.events = game.events  # TODO: This could be too big for the channel
 
 
 class GameListMessage:
     def __init__(self, game_list):
-        self.game_list = game_list
+        self.game_list = game_list  # TODO: This could be too big for the channel
 
 
 class CreateAGameMessage:
@@ -62,7 +62,7 @@ class GameListRequestMessage:
 
 class GameListResponseMessage:
     def __init__(self, games):
-        self.games = games
+        self.games = games  # TODO:  This could be too big for the channel
 
 
 class GameListResponseEntry:

--- a/server/engine/commands.py
+++ b/server/engine/commands.py
@@ -4,7 +4,8 @@ from .errors import InvalidCommandError
 from .persistence import Persistence
 import logging
 from common.messages import (
-    GameMessage,
+    GameInfoMessage,
+    GameEventsMessage,
     PingResponseMessage,
     GameListResponseMessage,
     GameListResponseEntry,
@@ -71,7 +72,7 @@ class PlaceSymbol(Command):
         game = self.load_game(self.game_id)
         game.place(self.player_id, self.position)
         self.save_game(game)
-        return GameMessage(game)
+        return GameEventsMessage(game)
 
 
 class SendChat(Command):
@@ -94,7 +95,7 @@ class SendChat(Command):
         game = self.load_game(self.game_id)
         game.add_chat_message(self.player_id, self.message)
         self.save_game(game)
-        return GameMessage(game)
+        return GameEventsMessage(game)
 
 
 class CreateGame(Command):
@@ -114,7 +115,7 @@ class CreateGame(Command):
         game = self.create_game(self.game_name, self.player_id)
         # Persist the new game on storage
         self.save_game(game)
-        return GameMessage(game)
+        return GameInfoMessage(game)
 
 
 class JoinGame(Command):
@@ -133,7 +134,7 @@ class JoinGame(Command):
         game = self.load_game(self.game_id)
         game.join(self.player_id)
         self.save_game(game)
-        return GameMessage(game)
+        return GameInfoMessage(game)
 
 
 class GameStatus(Command):
@@ -151,7 +152,7 @@ class GameStatus(Command):
         super().execute()
         game = self.load_game(self.game_id)
         game.player_can_get_status(self.player_id)
-        return GameMessage(game)
+        return GameEventsMessage(game)
 
 
 class Ping(Command):


### PR DESCRIPTION
There is no reason to keep together game events and general game info messages, specially since the event messages will be paginated to avoid them to increase indefintely, so I'm splitting them in two