### PR TITLE
Pass pointer when requesting game events

### DIFF
--- a/client/engine/commands.py
+++ b/client/engine/commands.py
@@ -231,9 +231,11 @@ class RequestJoiningAGame(Command):
 
 # ==== These are network requests
 class RefreshGameStatus(Command):
-    def __init__(self, profile, queue, game_id):
-        super().__init__(profile, queue, f"Refresh game status {game_id}")
-        self.events = [RefreshGameStatusNetworkRequestEvent(game_id)]
+    def __init__(self, profile, queue, game_id, pointer):
+        super().__init__(
+            profile, queue, f"Refresh game status {game_id} pointer {pointer}"
+        )
+        self.events = [RefreshGameStatusNetworkRequestEvent(game_id, pointer)]
 
 
 class CreateAGame(Command):

--- a/client/engine/commands.py
+++ b/client/engine/commands.py
@@ -208,11 +208,13 @@ class ChatMessageInGameCommand(Command):
 
 # ==== This one is to request the game status (polling)
 class RequestGameStatus(Command):
-    def __init__(self, profile, queue, game_id):
+    def __init__(self, profile, queue, game_id, pointer):
         super().__init__(
-            profile, queue, f"Request refreshing the status of game {game_id}"
+            profile,
+            queue,
+            f"Request refreshing the status of game {game_id} pointer {pointer}",
         )
-        self.events = [RefreshGameStatusEvent(game_id)]
+        self.events = [RefreshGameStatusEvent(game_id, pointer)]
 
 
 class RequestGameCreation(Command):

--- a/client/engine/event_handler.py
+++ b/client/engine/event_handler.py
@@ -78,6 +78,10 @@ class TurnSoundOffEventHandler(EventHandler):
 # ======= GAME STATE SYNC =======
 class UpdateGameEventHandler(EventHandler):
     def handle(self, events, client_state):
+        game_event_pointer = client_state.profile.game_event_pointer
+        client_state.profile.set_game_event_pointer(
+            game_event_pointer + len(events) - 1
+        )
         ProcessServerEvents(client_state.profile, client_state.queue, events).execute()
 
 

--- a/client/engine/event_handler.py
+++ b/client/engine/event_handler.py
@@ -107,7 +107,7 @@ class SetPlayerNameEventHandler(EventHandler):
 class RefreshGameStatusEventHandler(EventHandler):
     def handle(self, event, client_state):
         RefreshGameStatus(
-            client_state.profile, client_state.queue, event.game_id
+            client_state.profile, client_state.queue, event.game_id, event.pointer
         ).execute()
 
 
@@ -123,42 +123,23 @@ class JoinExistingGameEventHandler(EventHandler):
         JoinAGame(client_state.profile, client_state.queue, event.game_id).execute()
 
 
-"""
 class RefreshGameStatusNetworkRequestEventHandler(EventHandler):
     def handle(self, event, client_state):
-        request_data = self._encode(event.game_id, client_state.profile.id)
+        request_data = self._encode(
+            event.game_id, event.pointer, client_state.profile.id
+        )
 
         response = Channel.send_command(request_data)
         if response is not None:
+            # This will new be new events, not all
+            """TODO
             if isinstance(response, GameEventsMessage):
                 UpdateGame(
                     client_state.profile, client_state.queue, response.events
                 ).execute()
             if isinstance(response, ErrorMessage):
                 print(response.__dict__)
-        else:
-            print("Server error")
-            # This should be done at game level
-            # BackToLobby(client_state.profile, client_state.queue).execute()
-
-    def _encode(self, game_id, profile_id):
-        return GetGameStatus(game_id, profile_id)
-"""
-
-# Here instead of getting all events all the time, the client should only ask for new events
-# based on its pointer. And get one or many single event messages
-class RefreshGameStatusNetworkRequestEventHandler(EventHandler):
-    def handle(self, event, client_state):
-        request_data = self._encode(event.game_id, client_state.profile.id)
-
-        response = Channel.send_command(request_data)
-        if response is not None:
-            if isinstance(response, GameEventMessage):
-                UpdateGame(
-                    client_state.profile, client_state.queue, response.events
-                ).execute()
-            if isinstance(response, ErrorMessage):
-                print(response.__dict__)
+            """
         else:
             print("Server error")
             # This should be done at game level

--- a/client/engine/event_handler.py
+++ b/client/engine/event_handler.py
@@ -77,7 +77,8 @@ class TurnSoundOffEventHandler(EventHandler):
 
 # ======= GAME STATE SYNC =======
 class UpdateGameEventHandler(EventHandler):
-    def handle(self, events, client_state):
+    def handle(self, event, client_state):
+        events = event.events
         game_event_pointer = client_state.profile.game_event_pointer
         client_state.profile.set_game_event_pointer(
             game_event_pointer + len(events) - 1

--- a/client/engine/event_handler.py
+++ b/client/engine/event_handler.py
@@ -35,7 +35,8 @@ from .commands import (
 )
 from common.messages import (
     GameInfoMessage,
-    GameEventsMessage,
+    # GameEventsMessage,
+    GameEventMessage,
     ErrorMessage,
     GetGameStatus,
     CreateAGameMessage,
@@ -122,6 +123,7 @@ class JoinExistingGameEventHandler(EventHandler):
         JoinAGame(client_state.profile, client_state.queue, event.game_id).execute()
 
 
+"""
 class RefreshGameStatusNetworkRequestEventHandler(EventHandler):
     def handle(self, event, client_state):
         request_data = self._encode(event.game_id, client_state.profile.id)
@@ -129,6 +131,29 @@ class RefreshGameStatusNetworkRequestEventHandler(EventHandler):
         response = Channel.send_command(request_data)
         if response is not None:
             if isinstance(response, GameEventsMessage):
+                UpdateGame(
+                    client_state.profile, client_state.queue, response.events
+                ).execute()
+            if isinstance(response, ErrorMessage):
+                print(response.__dict__)
+        else:
+            print("Server error")
+            # This should be done at game level
+            # BackToLobby(client_state.profile, client_state.queue).execute()
+
+    def _encode(self, game_id, profile_id):
+        return GetGameStatus(game_id, profile_id)
+"""
+
+# Here instead of getting all events all the time, the client should only ask for new events
+# based on its pointer. And get one or many single event messages
+class RefreshGameStatusNetworkRequestEventHandler(EventHandler):
+    def handle(self, event, client_state):
+        request_data = self._encode(event.game_id, client_state.profile.id)
+
+        response = Channel.send_command(request_data)
+        if response is not None:
+            if isinstance(response, GameEventMessage):
                 UpdateGame(
                     client_state.profile, client_state.queue, response.events
                 ).execute()

--- a/client/engine/event_handler.py
+++ b/client/engine/event_handler.py
@@ -80,9 +80,7 @@ class UpdateGameEventHandler(EventHandler):
     def handle(self, event, client_state):
         events = event.events
         game_event_pointer = client_state.profile.game_event_pointer
-        client_state.profile.set_game_event_pointer(
-            game_event_pointer + len(events) - 1
-        )
+        client_state.profile.set_game_event_pointer(game_event_pointer + len(events))
         ProcessServerEvents(client_state.profile, client_state.queue, events).execute()
 
 

--- a/client/engine/event_handler.py
+++ b/client/engine/event_handler.py
@@ -133,8 +133,8 @@ class RefreshGameStatusNetworkRequestEventHandler(EventHandler):
             # This should be done at game level
             # BackToLobby(client_state.profile, client_state.queue).execute()
 
-    def _encode(self, game_id, profile_id):
-        return GetGameStatus(game_id, profile_id)
+    def _encode(self, game_id, pointer, profile_id):
+        return GetGameStatus(game_id, pointer, profile_id)
 
 
 class CreateAGameNetworkRequestEventHandler(EventHandler):

--- a/client/engine/event_handler.py
+++ b/client/engine/event_handler.py
@@ -35,8 +35,7 @@ from .commands import (
 )
 from common.messages import (
     GameInfoMessage,
-    # GameEventsMessage,
-    GameEventMessage,
+    GameEventsMessage,
     ErrorMessage,
     GetGameStatus,
     CreateAGameMessage,
@@ -78,19 +77,8 @@ class TurnSoundOffEventHandler(EventHandler):
 
 # ======= GAME STATE SYNC =======
 class UpdateGameEventHandler(EventHandler):
-    def handle(self, event, client_state):
-        # What we are going to do now is to check for unprocessed events
-        # there may be new events that have not been processed by the client,
-        # How do we know that? using the game_event_pointer.
-        events = event.events
-        game_event_pointer = client_state.profile.game_event_pointer
-        unprocessed_events = events[game_event_pointer + 1 :]
-        game_event_pointer = client_state.profile.set_game_event_pointer(
-            len(events) - 1
-        )
-        ProcessServerEvents(
-            client_state.profile, client_state.queue, unprocessed_events
-        ).execute()
+    def handle(self, events, client_state):
+        ProcessServerEvents(client_state.profile, client_state.queue, events).execute()
 
 
 class SetInternalGameInformationEventHandler(EventHandler):
@@ -131,15 +119,12 @@ class RefreshGameStatusNetworkRequestEventHandler(EventHandler):
 
         response = Channel.send_command(request_data)
         if response is not None:
-            # This will new be new events, not all
-            """TODO
             if isinstance(response, GameEventsMessage):
                 UpdateGame(
                     client_state.profile, client_state.queue, response.events
                 ).execute()
             if isinstance(response, ErrorMessage):
                 print(response.__dict__)
-            """
         else:
             print("Server error")
             # This should be done at game level

--- a/client/engine/events.py
+++ b/client/engine/events.py
@@ -81,9 +81,10 @@ class ChatMessageInGameEvent(Event):
 
 # This one is for polling
 class RefreshGameStatusEvent(Event):
-    def __init__(self, game_id):
+    def __init__(self, game_id, pointer):
         super().__init__()
         self.game_id = game_id
+        self.pointer = pointer
 
 
 class NewGameRequestEvent(Event):
@@ -100,9 +101,10 @@ class JoinExistingGameEvent(Event):
 
 # These are network requests
 class RefreshGameStatusNetworkRequestEvent(Event):
-    def __init__(self, game_id):
+    def __init__(self, game_id, pointer):
         super().__init__()
         self.game_id = game_id
+        self.pointer = pointer
 
 
 class CreateAGameNetworkRequestEvent(Event):

--- a/client/engine/screen_manager.py
+++ b/client/engine/screen_manager.py
@@ -30,7 +30,10 @@ class ScreenManager:
         game_id = self.client_state.profile.game_id
         if self.client_state.clock.get() % polling_rate == 0 and game_id is not None:
             RequestGameStatus(
-                self.client_state.profile, self.client_state.queue, game_id
+                self.client_state.profile,
+                self.client_state.queue,
+                game_id,
+                self.client_state.profile.game_event_pointer,
             ).execute()
 
     def run(self):

--- a/client/engine/tests/test_client.py
+++ b/client/engine/tests/test_client.py
@@ -202,20 +202,15 @@ class TestClient(TestCase):
 
         # The server will respond with a correct game message
         m_send_command.return_value = GameEventsMessage(
-            GameData(
-                "game_id",
-                "game_name",
-                ["player_1_id", "player_2_id"],
-                [
-                    "event_1",
-                    "event_2",
-                    "event_3",
-                ],
-            )
+            [
+                "event_1",
+                "event_2",
+                "event_3",
+            ]
         )
 
         # A request to get the game status is sourced
-        RequestGameStatus(self.profile, self.queue, "some_game_id").execute()
+        RequestGameStatus(self.profile, self.queue, "some_game_id", 2).execute()
         event = (
             self.queue.pop()
         )  # TODO: Manage the case of commands that queue several events

--- a/client/engine/tests/test_client.py
+++ b/client/engine/tests/test_client.py
@@ -111,8 +111,8 @@ class TestClient(TestCase):
         # There is no generic handler for this one, it is handled by the game on each screen
 
     def test_updating(self):
-        # When there are new events to process these will be pushed to the queue
-        already_processed_events = ["event_1"]
+        # There is already one processed event, so the pointer
+        # will be at 1.
         game_events = [
             "event_1",
             "event_2",
@@ -122,7 +122,7 @@ class TestClient(TestCase):
             key="key",
             id="id",
             game_id="game_id",
-            game_event_pointer=len(already_processed_events) - 1,
+            game_event_pointer=1,
             sound_on=False,
         )
         UpdateGame(profile, self.queue, game_events).execute()
@@ -136,14 +136,16 @@ class TestClient(TestCase):
         client_state.queue = self.queue
         self.event_handler.handle(event, client_state)
 
-        # Unprocessed events have been calculated and pushed to the queue
+        # The server is responding with the three events
+        unprocessed_event_1 = self.queue.pop()
+        assert unprocessed_event_1 == "event_1"
         unprocessed_event_1 = self.queue.pop()
         assert unprocessed_event_1 == "event_2"
         unprocessed_event_1 = self.queue.pop()
         assert unprocessed_event_1 == "event_3"
         assert (
-            client_state.profile.game_event_pointer == 2
-        )  # And the event pointer has been updated
+            client_state.profile.game_event_pointer == 4
+        )  # And now the event pointer is at 3
 
     def test_initializating_game(self):
         game_data = GameData(

--- a/client/game/event_handler.py
+++ b/client/game/event_handler.py
@@ -192,6 +192,7 @@ class SendChatRequestEventHandler(EventHandler):
         ).execute()
 
 
+# TODO: Here I will return somethin different
 class PlaceASymbolNetworkRequestEventHandler(EventHandler):
     def handle(self, event, client_state):
         request_data = self._encode(
@@ -208,12 +209,13 @@ class PlaceASymbolNetworkRequestEventHandler(EventHandler):
                 print(response.__dict__)
         else:
             print("Server error")
-            BackToLobby(client_state.profile, client_state.queue).execute()
+            # BackToLobby(client_state.profile, client_state.queue).execute()
 
     def _encode(self, game_id, profile_id, position):
         return PlaceASymbolMessage(game_id, profile_id, position)
 
 
+# TODO: Here I will return somethin different
 class SendChatNetworkRequestEventHandler(EventHandler):
     def handle(self, event, client_state):
         request_data = self._encode(
@@ -230,7 +232,7 @@ class SendChatNetworkRequestEventHandler(EventHandler):
                 print(response.__dict__)
         else:
             print("Server error")
-            BackToLobby(client_state.profile, client_state.queue).execute()
+            # BackToLobby(client_state.profile, client_state.queue).execute()
 
     def _encode(self, game_id, profile_id, message):
         return SendChatMessage(game_id, profile_id, message)

--- a/common/messages.py
+++ b/common/messages.py
@@ -5,16 +5,9 @@ class GameInfoMessage:
         self.players = game.players
 
 
-# This is the new sync mechanism
-class GameEventMessage:
-    def __init__(self, event):
-        self.event = event
-
-
-# This is the old sync mechanism
 class GameEventsMessage:
-    def __init__(self, game):
-        self.events = game.events  # TODO: This could be too big for the channel
+    def __init__(self, events):
+        self.events = events  # TODO: This could be too big for the channel
 
 
 class GameListMessage:

--- a/common/messages.py
+++ b/common/messages.py
@@ -47,8 +47,9 @@ class ErrorMessage:
 
 
 class GetGameStatus:
-    def __init__(self, game_id, player_id):
+    def __init__(self, game_id, pointer, player_id):
         self.game_id = game_id
+        self.pointer = pointer
         self.player_id = player_id
 
 

--- a/common/messages.py
+++ b/common/messages.py
@@ -5,6 +5,13 @@ class GameInfoMessage:
         self.players = game.players
 
 
+# This is the new sync mechanism
+class GameEventMessage:
+    def __init__(self, event):
+        self.event = event
+
+
+# This is the old sync mechanism
 class GameEventsMessage:
     def __init__(self, game):
         self.events = game.events  # TODO: This could be too big for the channel

--- a/server/engine/commands.py
+++ b/server/engine/commands.py
@@ -72,6 +72,7 @@ class PlaceSymbol(Command):
         game = self.load_game(self.game_id)
         game.place(self.player_id, self.position)
         self.save_game(game)
+        # Send just an ACK
         # This becomes is too big
         # return GameEventsMessage(game)
         # Instead of doing this send a confirmation response
@@ -97,6 +98,7 @@ class SendChat(Command):
         game = self.load_game(self.game_id)
         game.add_chat_message(self.player_id, self.message)
         self.save_game(game)
+        # Send just an ACK
         # This becomes is too big
         # return GameEventsMessage(game)
         # Instead of doing this send a confirmation response

--- a/server/engine/commands.py
+++ b/server/engine/commands.py
@@ -5,8 +5,7 @@ from .persistence import Persistence
 import logging
 from common.messages import (
     GameInfoMessage,
-    GameEventMessage,
-    # GameEventsMessage,
+    GameEventsMessage,
     PingResponseMessage,
     GameListResponseMessage,
     GameListResponseEntry,
@@ -160,13 +159,8 @@ class GameStatus(Command):
         super().execute()
         game = self.load_game(self.game_id)
         game.player_can_get_status(self.player_id)
-        # TODO: Get the events from the pointer and add them to the message
-        # This becomes is too big
-        # return GameEventsMessage(game)
-        # Instead of sendin the whole game status message
-        # do a more efficient sync mechanism
-        # And send single GameEvent Message messages
-        # for the unprocessed events
+        events = game.events[self.pointer :]
+        return GameEventsMessage(events)
 
 
 class Ping(Command):

--- a/server/engine/commands.py
+++ b/server/engine/commands.py
@@ -5,7 +5,8 @@ from .persistence import Persistence
 import logging
 from common.messages import (
     GameInfoMessage,
-    GameEventsMessage,
+    GameEventMessage,
+    # GameEventsMessage,
     PingResponseMessage,
     GameListResponseMessage,
     GameListResponseEntry,
@@ -72,7 +73,9 @@ class PlaceSymbol(Command):
         game = self.load_game(self.game_id)
         game.place(self.player_id, self.position)
         self.save_game(game)
-        return GameEventsMessage(game)
+        # This becomes is too big
+        # return GameEventsMessage(game)
+        # Instead of doing this send a confirmation response
 
 
 class SendChat(Command):
@@ -95,7 +98,9 @@ class SendChat(Command):
         game = self.load_game(self.game_id)
         game.add_chat_message(self.player_id, self.message)
         self.save_game(game)
-        return GameEventsMessage(game)
+        # This becomes is too big
+        # return GameEventsMessage(game)
+        # Instead of doing this send a confirmation response
 
 
 class CreateGame(Command):
@@ -152,7 +157,12 @@ class GameStatus(Command):
         super().execute()
         game = self.load_game(self.game_id)
         game.player_can_get_status(self.player_id)
-        return GameEventsMessage(game)
+        # This becomes is too big
+        # return GameEventsMessage(game)
+        # Instead of sendin the whole game status message
+        # do a more efficient sync mechanism
+        # And send single GameEvent Message messages
+        # for the unprocessed events
 
 
 class Ping(Command):

--- a/server/engine/commands.py
+++ b/server/engine/commands.py
@@ -143,20 +143,24 @@ class JoinGame(Command):
 
 
 class GameStatus(Command):
-    def __init__(self, game_id, player_id):
+    def __init__(self, game_id, pointer, player_id):
         self.game_id = game_id
+        self.pointer = pointer
         self.player_id = player_id
 
     def name(self):
         return "Get game status"
 
     def debug(self):
-        logger.info(f"Player {self.player_id} requested info for game: {self.game_id}")
+        logger.info(
+            f"Player {self.player_id} requested info for game: {self.game_id}, pointer {self.pointer}"
+        )
 
     def execute(self):
         super().execute()
         game = self.load_game(self.game_id)
         game.player_can_get_status(self.player_id)
+        # TODO: Get the events from the pointer and add them to the message
         # This becomes is too big
         # return GameEventsMessage(game)
         # Instead of sendin the whole game status message

--- a/server/engine/server.py
+++ b/server/engine/server.py
@@ -42,7 +42,7 @@ class ThreadedTCPRequestHandler(socketserver.BaseRequestHandler):
         if isinstance(decoded, JoinAGameMessage):
             return JoinGame(decoded.game_id, decoded.player_id)
         if isinstance(decoded, GetGameStatus):
-            return GameStatus(decoded.game_id, decoded.player_id)
+            return GameStatus(decoded.game_id, decoded.pointer, decoded.player_id)
         if isinstance(decoded, PingRequestMessage):
             return Ping()
         if isinstance(decoded, GameListRequestMessage):


### PR DESCRIPTION
Fixes #10  now instead of sending the entire game data, the client only asks for new events, so the request to the server contains a pointer indicating what events the client is already aware of. Then the server responds only with the new events and the client will update its pointer upon receiving these events.
There are of course more issues, but now the games won't crash when the game information starts to grow.