### PR TITLE
Use Generics

### DIFF
--- a/.mypy.ini
+++ b/.mypy.ini
@@ -1,5 +1,4 @@
 [mypy]
-disable_error_code = override
 exclude = ideas
 [mypy-mock.*]
 ignore_missing_imports = True

--- a/client/engine/event_handler.py
+++ b/client/engine/event_handler.py
@@ -36,7 +36,7 @@ from .events import (
 
 if TYPE_CHECKING:
     from client.engine.general_state.client_state import ClientState
-    from client.engine.primitives.event import E, Event
+    from client.engine.primitives.event import Event
 
 logger = logging.getLogger(__name__)
 
@@ -90,14 +90,14 @@ class PingNetworkRequestEventHandler(BaseEventHandler[PingNetworkRequestEvent]):
         return PingRequestMessage()
 
 
-common_handlers: Dict[Type["E"], Type[BaseEventHandler["E"]]] = {
+common_handlers: Dict[Type["Event"], Type[BaseEventHandler["Event"]]] = {
     QuitGameEvent: QuitGameEventHandler,
     PingNetworkRequestEvent: PingNetworkRequestEventHandler,
     SetInternalGameInformationEvent: SetInternalGameInformationEventHandler,
     SetPlayerNameEvent: SetPlayerNameEventHandler,
 }
 
-handlers_map: Dict[Type["E"], Type[BaseEventHandler["E"]]] = {
+handlers_map: Dict[Type["Event"], Type[BaseEventHandler["Event"]]] = {
     **common_handlers,
     **chat_event_handlers,
     **pieces_event_handlers,

--- a/client/engine/event_handler.py
+++ b/client/engine/event_handler.py
@@ -90,14 +90,14 @@ class PingNetworkRequestEventHandler(BaseEventHandler[PingNetworkRequestEvent]):
         return PingRequestMessage()
 
 
-common_handlers: Dict[Type["Event"], Type[BaseEventHandler["Event"]]] = {
+common_handlers = {
     QuitGameEvent: QuitGameEventHandler,
     PingNetworkRequestEvent: PingNetworkRequestEventHandler,
     SetInternalGameInformationEvent: SetInternalGameInformationEventHandler,
     SetPlayerNameEvent: SetPlayerNameEventHandler,
 }
 
-handlers_map: Dict[Type["Event"], Type[BaseEventHandler["Event"]]] = {
+handlers_map = {
     **common_handlers,
     **chat_event_handlers,
     **pieces_event_handlers,

--- a/client/engine/event_handler.py
+++ b/client/engine/event_handler.py
@@ -36,7 +36,7 @@ from .events import (
 
 if TYPE_CHECKING:
     from client.engine.general_state.client_state import ClientState
-    from client.engine.primitives.event import Event
+    from client.engine.primitives.event import E, Event
 
 logger = logging.getLogger(__name__)
 
@@ -47,7 +47,7 @@ They do the actual procssing and can execute commands.
 
 
 # ======= GENERIC =======
-class QuitGameEventHandler(BaseEventHandler):
+class QuitGameEventHandler(BaseEventHandler[QuitGameEvent]):
     def handle(self, event: "QuitGameEvent", client_state: "ClientState") -> None:
         import sys
 
@@ -56,7 +56,9 @@ class QuitGameEventHandler(BaseEventHandler):
 
 
 # ======= GAME STATE SYNC =======
-class SetInternalGameInformationEventHandler(BaseEventHandler):
+class SetInternalGameInformationEventHandler(
+    BaseEventHandler[SetInternalGameInformationEvent]
+):
     def handle(
         self, event: "SetInternalGameInformationEvent", client_state: "ClientState"
     ) -> None:
@@ -64,12 +66,12 @@ class SetInternalGameInformationEventHandler(BaseEventHandler):
         client_state.profile.set_game_event_pointer(0)
 
 
-class SetPlayerNameEventHandler(BaseEventHandler):
+class SetPlayerNameEventHandler(BaseEventHandler[SetPlayerNameEvent]):
     def handle(self, event: "SetPlayerNameEvent", client_state: "ClientState") -> None:
         client_state.profile.set_name(event.name)
 
 
-class PingNetworkRequestEventHandler(BaseEventHandler):
+class PingNetworkRequestEventHandler(BaseEventHandler[PingNetworkRequestEvent]):
     def handle(
         self, event: "PingNetworkRequestEvent", client_state: "ClientState"
     ) -> None:
@@ -88,14 +90,14 @@ class PingNetworkRequestEventHandler(BaseEventHandler):
         return PingRequestMessage()
 
 
-common_handlers: Dict[Type["Event"], Type[BaseEventHandler]] = {
+common_handlers: Dict[Type["E"], Type[BaseEventHandler["E"]]] = {
     QuitGameEvent: QuitGameEventHandler,
     PingNetworkRequestEvent: PingNetworkRequestEventHandler,
     SetInternalGameInformationEvent: SetInternalGameInformationEventHandler,
     SetPlayerNameEvent: SetPlayerNameEventHandler,
 }
 
-handlers_map: Dict[Type["Event"], Type[BaseEventHandler]] = {
+handlers_map: Dict[Type["E"], Type[BaseEventHandler["E"]]] = {
     **common_handlers,
     **chat_event_handlers,
     **pieces_event_handlers,
@@ -107,6 +109,6 @@ handlers_map: Dict[Type["Event"], Type[BaseEventHandler]] = {
 }
 
 
-class EventHandler(BaseEventHandler):
+class EventHandler(BaseEventHandler["Event"]):
     def handle(self, event: "Event", client_state: "ClientState") -> None:
         handlers_map[type(event)]().handle(event, client_state)

--- a/client/engine/events_processor.py
+++ b/client/engine/events_processor.py
@@ -10,10 +10,10 @@ if TYPE_CHECKING:
 
 
 class EventsProcessor:
-    def __init__(self, event_handlers: List["EventHandler"]):
+    def __init__(self, event_handlers: List["EventHandler[Event]"]):
         self.event_handlers = event_handlers  # Initial list of event handlers
 
-    def add_event_handler(self, event_handler: "EventHandler") -> None:
+    def add_event_handler(self, event_handler: "EventHandler[Event]") -> None:
         self.event_handlers.append(event_handler)
 
     def handle(self, event: "Event", client_state: "ClientState") -> None:

--- a/client/engine/features/chat/event_handler.py
+++ b/client/engine/features/chat/event_handler.py
@@ -91,7 +91,7 @@ class SendChatNetworkRequestEventHandler(EventHandler[SendChatNetworkRequestEven
         return SendChatMessage(game_id, event_id, profile_id, message)
 
 
-handlers_map: Dict[Type["Event"], Type[EventHandler["Event"]]] = {
+handlers_map = {
     SendChatRequestEvent: SendChatRequestEventHandler,
     SendChatNetworkRequestEvent: SendChatNetworkRequestEventHandler,
     ChatMessageInGameEvent: ChatMessageInGameEventHandler,

--- a/client/engine/features/chat/event_handler.py
+++ b/client/engine/features/chat/event_handler.py
@@ -19,7 +19,7 @@ if TYPE_CHECKING:
     from uuid import UUID
 
     from client.engine.general_state.client_state import ClientState
-    from client.engine.primitives.event import E, Event
+    from client.engine.primitives.event import Event
 
 logger = logging.getLogger(__name__)
 
@@ -91,7 +91,7 @@ class SendChatNetworkRequestEventHandler(EventHandler[SendChatNetworkRequestEven
         return SendChatMessage(game_id, event_id, profile_id, message)
 
 
-handlers_map: Dict[Type["E"], Type[EventHandler["E"]]] = {
+handlers_map: Dict[Type["Event"], Type[EventHandler["Event"]]] = {
     SendChatRequestEvent: SendChatRequestEventHandler,
     SendChatNetworkRequestEvent: SendChatNetworkRequestEventHandler,
     ChatMessageInGameEvent: ChatMessageInGameEventHandler,

--- a/client/engine/features/chat/event_handler.py
+++ b/client/engine/features/chat/event_handler.py
@@ -19,12 +19,12 @@ if TYPE_CHECKING:
     from uuid import UUID
 
     from client.engine.general_state.client_state import ClientState
-    from client.engine.primitives.event import Event
+    from client.engine.primitives.event import E, Event
 
 logger = logging.getLogger(__name__)
 
 
-class ChatMessageInGameEventHandler(EventHandler):
+class ChatMessageInGameEventHandler(EventHandler[ChatMessageInGameEvent]):
     def handle(
         self, event: "ChatMessageInGameEvent", client_state: "ClientState"
     ) -> None:
@@ -38,7 +38,7 @@ class ChatMessageInGameEventHandler(EventHandler):
         ).execute()
 
 
-class SendChatRequestEventHandler(EventHandler):
+class SendChatRequestEventHandler(EventHandler[SendChatRequestEvent]):
     def handle(
         self, event: "SendChatRequestEvent", client_state: "ClientState"
     ) -> None:
@@ -54,7 +54,7 @@ class SendChatRequestEventHandler(EventHandler):
         ).execute()
 
 
-class SendChatNetworkRequestEventHandler(EventHandler):
+class SendChatNetworkRequestEventHandler(EventHandler[SendChatNetworkRequestEvent]):
     def handle(
         self, event: "SendChatNetworkRequestEvent", client_state: "ClientState"
     ) -> None:
@@ -91,7 +91,7 @@ class SendChatNetworkRequestEventHandler(EventHandler):
         return SendChatMessage(game_id, event_id, profile_id, message)
 
 
-handlers_map: Dict[Type["Event"], Type[EventHandler]] = {
+handlers_map: Dict[Type["E"], Type[EventHandler["E"]]] = {
     SendChatRequestEvent: SendChatRequestEventHandler,
     SendChatNetworkRequestEvent: SendChatNetworkRequestEventHandler,
     ChatMessageInGameEvent: ChatMessageInGameEventHandler,

--- a/client/engine/features/game_list/event_handler.py
+++ b/client/engine/features/game_list/event_handler.py
@@ -14,7 +14,7 @@ from .events import GetGameListNetworkRequestEvent
 
 if TYPE_CHECKING:
     from client.engine.general_state.client_state import ClientState
-    from client.engine.primitives.event import E, Event
+    from client.engine.primitives.event import Event
 
 
 logger = logging.getLogger(__name__)
@@ -55,6 +55,6 @@ class GetGameListNetworkRequestEventHandler(
         return GameListRequestMessage()
 
 
-handlers_map: Dict[Type["E"], Type[EventHandler["E"]]] = {
+handlers_map: Dict[Type["Event"], Type[EventHandler["Event"]]] = {
     GetGameListNetworkRequestEvent: GetGameListNetworkRequestEventHandler
 }

--- a/client/engine/features/game_list/event_handler.py
+++ b/client/engine/features/game_list/event_handler.py
@@ -14,17 +14,19 @@ from .events import GetGameListNetworkRequestEvent
 
 if TYPE_CHECKING:
     from client.engine.general_state.client_state import ClientState
-    from client.engine.primitives.event import Event
+    from client.engine.primitives.event import E, Event
 
 
 logger = logging.getLogger(__name__)
 
 
-class ErrorGettingGameListEventHandler(EventHandler):
+class ErrorGettingGameListEventHandler(EventHandler["Event"]):
     pass
 
 
-class GetGameListNetworkRequestEventHandler(EventHandler):
+class GetGameListNetworkRequestEventHandler(
+    EventHandler[GetGameListNetworkRequestEvent]
+):
     def handle(
         self, event: "GetGameListNetworkRequestEvent", client_state: "ClientState"
     ) -> None:
@@ -53,6 +55,6 @@ class GetGameListNetworkRequestEventHandler(EventHandler):
         return GameListRequestMessage()
 
 
-handlers_map: Dict[Type["Event"], Type[EventHandler]] = {
+handlers_map: Dict[Type["E"], Type[EventHandler["E"]]] = {
     GetGameListNetworkRequestEvent: GetGameListNetworkRequestEventHandler
 }

--- a/client/engine/features/game_list/event_handler.py
+++ b/client/engine/features/game_list/event_handler.py
@@ -55,6 +55,4 @@ class GetGameListNetworkRequestEventHandler(
         return GameListRequestMessage()
 
 
-handlers_map: Dict[Type["Event"], Type[EventHandler["Event"]]] = {
-    GetGameListNetworkRequestEvent: GetGameListNetworkRequestEventHandler
-}
+handlers_map = {GetGameListNetworkRequestEvent: GetGameListNetworkRequestEventHandler}

--- a/client/engine/features/game_management/event_handler.py
+++ b/client/engine/features/game_management/event_handler.py
@@ -114,7 +114,7 @@ class JoinAGameNetworkRequestEventHandler(EventHandler[JoinAGameNetworkRequestEv
         return JoinAGameMessage(game_id, profile_id)
 
 
-handlers_map: Dict[Type["Event"], Type[EventHandler["Event"]]] = {
+handlers_map = {
     CreateAGameNetworkRequestEvent: CreateAGameNetworkRequestEventHandler,
     JoinAGameNetworkRequestEvent: JoinAGameNetworkRequestEventHandler,
     NewGameRequestEvent: NewGameRequestEventHandler,

--- a/client/engine/features/game_management/event_handler.py
+++ b/client/engine/features/game_management/event_handler.py
@@ -24,7 +24,7 @@ if TYPE_CHECKING:
     from uuid import UUID
 
     from client.engine.general_state.client_state import ClientState
-    from client.engine.primitives.event import E, Event
+    from client.engine.primitives.event import Event
 
 
 logger = logging.getLogger(__name__)
@@ -114,7 +114,7 @@ class JoinAGameNetworkRequestEventHandler(EventHandler[JoinAGameNetworkRequestEv
         return JoinAGameMessage(game_id, profile_id)
 
 
-handlers_map: Dict[Type["E"], Type[EventHandler["E"]]] = {
+handlers_map: Dict[Type["Event"], Type[EventHandler["Event"]]] = {
     CreateAGameNetworkRequestEvent: CreateAGameNetworkRequestEventHandler,
     JoinAGameNetworkRequestEvent: JoinAGameNetworkRequestEventHandler,
     NewGameRequestEvent: NewGameRequestEventHandler,

--- a/client/engine/features/game_management/event_handler.py
+++ b/client/engine/features/game_management/event_handler.py
@@ -24,27 +24,29 @@ if TYPE_CHECKING:
     from uuid import UUID
 
     from client.engine.general_state.client_state import ClientState
-    from client.engine.primitives.event import Event
+    from client.engine.primitives.event import E, Event
 
 
 logger = logging.getLogger(__name__)
 
 
-class NewGameRequestEventHandler(EventHandler):
+class NewGameRequestEventHandler(EventHandler[NewGameRequestEvent]):
     def handle(self, event: "NewGameRequestEvent", client_state: "ClientState") -> None:
         CreateAGame(
             client_state.profile, client_state.queue, event.new_game_name
         ).execute()
 
 
-class JoinExistingGameEventHandler(EventHandler):
+class JoinExistingGameEventHandler(EventHandler[JoinExistingGameEvent]):
     def handle(
         self, event: "JoinExistingGameEvent", client_state: "ClientState"
     ) -> None:
         JoinAGame(client_state.profile, client_state.queue, event.game_id).execute()
 
 
-class CreateAGameNetworkRequestEventHandler(EventHandler):
+class CreateAGameNetworkRequestEventHandler(
+    EventHandler[CreateAGameNetworkRequestEvent]
+):
     def handle(
         self, event: "CreateAGameNetworkRequestEvent", client_state: "ClientState"
     ) -> None:
@@ -80,7 +82,7 @@ class CreateAGameNetworkRequestEventHandler(EventHandler):
         return CreateAGameMessage(new_game_name, profile_id)
 
 
-class JoinAGameNetworkRequestEventHandler(EventHandler):
+class JoinAGameNetworkRequestEventHandler(EventHandler[JoinAGameNetworkRequestEvent]):
     def handle(
         self, event: "JoinAGameNetworkRequestEvent", client_state: "ClientState"
     ) -> None:
@@ -112,7 +114,7 @@ class JoinAGameNetworkRequestEventHandler(EventHandler):
         return JoinAGameMessage(game_id, profile_id)
 
 
-handlers_map: Dict[Type["Event"], Type[EventHandler]] = {
+handlers_map: Dict[Type["E"], Type[EventHandler["E"]]] = {
     CreateAGameNetworkRequestEvent: CreateAGameNetworkRequestEventHandler,
     JoinAGameNetworkRequestEvent: JoinAGameNetworkRequestEventHandler,
     NewGameRequestEvent: NewGameRequestEventHandler,

--- a/client/engine/features/pieces/event_handler.py
+++ b/client/engine/features/pieces/event_handler.py
@@ -21,13 +21,13 @@ if TYPE_CHECKING:
     from uuid import UUID
 
     from client.engine.general_state.client_state import ClientState
-    from client.engine.primitives.event import Event
+    from client.engine.primitives.event import E, Event
 
 
 logger = logging.getLogger(__name__)
 
 
-class PlayerPlacedSymbolInGameEventHandler(EventHandler):
+class PlayerPlacedSymbolInGameEventHandler(EventHandler[PlayerPlacedSymbolInGameEvent]):
     def handle(
         self, event: "PlayerPlacedSymbolInGameEvent", client_state: "ClientState"
     ) -> None:
@@ -40,7 +40,7 @@ class PlayerPlacedSymbolInGameEventHandler(EventHandler):
         ).execute()
 
 
-class PlaceASymbolRequestEventHandler(EventHandler):
+class PlaceASymbolRequestEventHandler(EventHandler[PlaceASymbolRequestEvent]):
     def handle(
         self, event: "PlaceASymbolRequestEvent", client_state: "ClientState"
     ) -> None:
@@ -56,7 +56,9 @@ class PlaceASymbolRequestEventHandler(EventHandler):
         ).execute()
 
 
-class PlaceASymbolNetworkRequestEventHandler(EventHandler):
+class PlaceASymbolNetworkRequestEventHandler(
+    EventHandler[PlaceASymbolNetworkRequestEvent]
+):
     def handle(
         self, event: "PlaceASymbolNetworkRequestEvent", client_state: "ClientState"
     ) -> None:
@@ -93,7 +95,7 @@ class PlaceASymbolNetworkRequestEventHandler(EventHandler):
         return PlaceASymbolMessage(game_id, event_id, profile_id, position)
 
 
-handlers_map: Dict[Type["Event"], Type[EventHandler]] = {
+handlers_map: Dict[Type["E"], Type[EventHandler["E"]]] = {
     PlaceASymbolRequestEvent: PlaceASymbolRequestEventHandler,
     PlaceASymbolNetworkRequestEvent: PlaceASymbolNetworkRequestEventHandler,
     PlayerPlacedSymbolInGameEvent: PlayerPlacedSymbolInGameEventHandler,

--- a/client/engine/features/pieces/event_handler.py
+++ b/client/engine/features/pieces/event_handler.py
@@ -21,7 +21,7 @@ if TYPE_CHECKING:
     from uuid import UUID
 
     from client.engine.general_state.client_state import ClientState
-    from client.engine.primitives.event import E, Event
+    from client.engine.primitives.event import Event
 
 
 logger = logging.getLogger(__name__)
@@ -95,7 +95,7 @@ class PlaceASymbolNetworkRequestEventHandler(
         return PlaceASymbolMessage(game_id, event_id, profile_id, position)
 
 
-handlers_map: Dict[Type["E"], Type[EventHandler["E"]]] = {
+handlers_map: Dict[Type["Event"], Type[EventHandler["Event"]]] = {
     PlaceASymbolRequestEvent: PlaceASymbolRequestEventHandler,
     PlaceASymbolNetworkRequestEvent: PlaceASymbolNetworkRequestEventHandler,
     PlayerPlacedSymbolInGameEvent: PlayerPlacedSymbolInGameEventHandler,

--- a/client/engine/features/pieces/event_handler.py
+++ b/client/engine/features/pieces/event_handler.py
@@ -95,7 +95,7 @@ class PlaceASymbolNetworkRequestEventHandler(
         return PlaceASymbolMessage(game_id, event_id, profile_id, position)
 
 
-handlers_map: Dict[Type["Event"], Type[EventHandler["Event"]]] = {
+handlers_map = {
     PlaceASymbolRequestEvent: PlaceASymbolRequestEventHandler,
     PlaceASymbolNetworkRequestEvent: PlaceASymbolNetworkRequestEventHandler,
     PlayerPlacedSymbolInGameEvent: PlayerPlacedSymbolInGameEventHandler,

--- a/client/engine/features/profile/event_handler.py
+++ b/client/engine/features/profile/event_handler.py
@@ -9,25 +9,25 @@ from .events import GetProfilesEvent, NewProfileEvent, SetProfileEvent
 
 if TYPE_CHECKING:
     from client.engine.general_state.client_state import ClientState
-    from client.engine.primitives.event import Event
+    from client.engine.primitives.event import E, Event
 
 
 logger = logging.getLogger(__name__)
 
 
-class SetProfileEventHandler(EventHandler):
+class SetProfileEventHandler(EventHandler[SetProfileEvent]):
     def handle(self, event: "SetProfileEvent", client_state: "ClientState") -> None:
         client_state.set_profile(event.key)
         ProfileIsSet(client_state.profile, client_state.queue, event.key).execute()
 
 
-class NewProfileEventHandler(EventHandler):
+class NewProfileEventHandler(EventHandler[NewProfileEvent]):
     def handle(self, event: "NewProfileEvent", client_state: "ClientState") -> None:
         new_profile_key = client_state.new_profile().key
         SetProfile(client_state.profile, client_state.queue, new_profile_key).execute()
 
 
-class GetProfilesEventHandler(EventHandler):
+class GetProfilesEventHandler(EventHandler[GetProfilesEvent]):
     def handle(self, event: "GetProfilesEvent", client_state: "ClientState") -> None:
         # TODO retrieve profiles from disk
         profiles = self._build_profiles_index(Persistence.list())
@@ -38,7 +38,7 @@ class GetProfilesEventHandler(EventHandler):
         return [{"name": profile} for profile in profiles if profile != ".gitkeep"]
 
 
-handlers_map: Dict[Type["Event"], Type[EventHandler]] = {
+handlers_map: Dict[Type["E"], Type[EventHandler["E"]]] = {
     SetProfileEvent: SetProfileEventHandler,
     NewProfileEvent: NewProfileEventHandler,
     GetProfilesEvent: GetProfilesEventHandler,

--- a/client/engine/features/profile/event_handler.py
+++ b/client/engine/features/profile/event_handler.py
@@ -38,7 +38,7 @@ class GetProfilesEventHandler(EventHandler[GetProfilesEvent]):
         return [{"name": profile} for profile in profiles if profile != ".gitkeep"]
 
 
-handlers_map: Dict[Type["Event"], Type[EventHandler["Event"]]] = {
+handlers_map = {
     SetProfileEvent: SetProfileEventHandler,
     NewProfileEvent: NewProfileEventHandler,
     GetProfilesEvent: GetProfilesEventHandler,

--- a/client/engine/features/profile/event_handler.py
+++ b/client/engine/features/profile/event_handler.py
@@ -9,7 +9,7 @@ from .events import GetProfilesEvent, NewProfileEvent, SetProfileEvent
 
 if TYPE_CHECKING:
     from client.engine.general_state.client_state import ClientState
-    from client.engine.primitives.event import E, Event
+    from client.engine.primitives.event import Event
 
 
 logger = logging.getLogger(__name__)
@@ -38,7 +38,7 @@ class GetProfilesEventHandler(EventHandler[GetProfilesEvent]):
         return [{"name": profile} for profile in profiles if profile != ".gitkeep"]
 
 
-handlers_map: Dict[Type["E"], Type[EventHandler["E"]]] = {
+handlers_map: Dict[Type["Event"], Type[EventHandler["Event"]]] = {
     SetProfileEvent: SetProfileEventHandler,
     NewProfileEvent: NewProfileEventHandler,
     GetProfilesEvent: GetProfilesEventHandler,

--- a/client/engine/features/sound/event_handler.py
+++ b/client/engine/features/sound/event_handler.py
@@ -37,7 +37,7 @@ class PlayMusicEventHandler(EventHandler[PlayMusicEvent]):
             Music.play()
 
 
-handlers_map: Dict[Type["Event"], Type[EventHandler["Event"]]] = {
+handlers_map = {
     TurnSoundOnEvent: TurnSoundOnEventHandler,
     TurnSoundOffEvent: TurnSoundOffEventHandler,
     PlaySoundEvent: PlaySoundEventHandler,

--- a/client/engine/features/sound/event_handler.py
+++ b/client/engine/features/sound/event_handler.py
@@ -9,35 +9,35 @@ from .events import PlayMusicEvent, PlaySoundEvent, TurnSoundOffEvent, TurnSound
 
 if TYPE_CHECKING:
     from client.engine.general_state.client_state import ClientState
-    from client.engine.primitives.event import Event
+    from client.engine.primitives.event import E, Event
 
 logger = logging.getLogger(__name__)
 
 
-class TurnSoundOnEventHandler(EventHandler):
+class TurnSoundOnEventHandler(EventHandler[TurnSoundOnEvent]):
     def handle(self, event: "TurnSoundOnEvent", client_state: "ClientState") -> None:
         client_state.profile.set_sound_on()
 
 
-class TurnSoundOffEventHandler(EventHandler):
+class TurnSoundOffEventHandler(EventHandler[TurnSoundOffEvent]):
     def handle(self, event: "TurnSoundOffEvent", client_state: "ClientState") -> None:
         client_state.profile.set_sound_off()
 
 
-class PlaySoundEventHandler(EventHandler):
+class PlaySoundEventHandler(EventHandler[PlaySoundEvent]):
     def handle(self, event: "PlaySoundEvent", client_state: "ClientState") -> None:
         if client_state.profile.sound_on:
             Sound.play(event.sound)
 
 
-class PlayMusicEventHandler(EventHandler):
+class PlayMusicEventHandler(EventHandler[PlayMusicEvent]):
     def handle(self, event: "PlayMusicEvent", client_state: "ClientState") -> None:
         if client_state.profile.sound_on:
             Music.load(event.music)
             Music.play()
 
 
-handlers_map: Dict[Type["Event"], Type[EventHandler]] = {
+handlers_map: Dict[Type["E"], Type[EventHandler["E"]]] = {
     TurnSoundOnEvent: TurnSoundOnEventHandler,
     TurnSoundOffEvent: TurnSoundOffEventHandler,
     PlaySoundEvent: PlaySoundEventHandler,

--- a/client/engine/features/sound/event_handler.py
+++ b/client/engine/features/sound/event_handler.py
@@ -9,7 +9,7 @@ from .events import PlayMusicEvent, PlaySoundEvent, TurnSoundOffEvent, TurnSound
 
 if TYPE_CHECKING:
     from client.engine.general_state.client_state import ClientState
-    from client.engine.primitives.event import E, Event
+    from client.engine.primitives.event import Event
 
 logger = logging.getLogger(__name__)
 
@@ -37,7 +37,7 @@ class PlayMusicEventHandler(EventHandler[PlayMusicEvent]):
             Music.play()
 
 
-handlers_map: Dict[Type["E"], Type[EventHandler["E"]]] = {
+handlers_map: Dict[Type["Event"], Type[EventHandler["Event"]]] = {
     TurnSoundOnEvent: TurnSoundOnEventHandler,
     TurnSoundOffEvent: TurnSoundOffEventHandler,
     PlaySoundEvent: PlaySoundEventHandler,

--- a/client/engine/features/synchronization/event_handler.py
+++ b/client/engine/features/synchronization/event_handler.py
@@ -69,7 +69,7 @@ class RefreshGameStatusNetworkRequestEventHandler(
         return GetGameStatus(game_id, pointer, profile_id)
 
 
-handlers_map: Dict[Type["Event"], Type[EventHandler["Event"]]] = {
+handlers_map = {
     UpdateGameEvent: UpdateGameEventHandler,
     RefreshGameStatusEvent: RefreshGameStatusEventHandler,
     RefreshGameStatusNetworkRequestEvent: RefreshGameStatusNetworkRequestEventHandler,

--- a/client/engine/features/synchronization/event_handler.py
+++ b/client/engine/features/synchronization/event_handler.py
@@ -2,7 +2,7 @@ import logging
 from typing import TYPE_CHECKING, Dict, Type
 
 from client.engine.network.channel import Channel
-from client.engine.primitives.event_handler import EventHandler
+from client.engine.primitives.event_handler import E, EventHandler
 from common.messages import ErrorMessage, GameEventsMessage, GetGameStatus
 
 from .commands import ProcessServerEvents, RefreshGameStatus, UpdateGame
@@ -21,7 +21,7 @@ if TYPE_CHECKING:
 logger = logging.getLogger(__name__)
 
 
-class UpdateGameEventHandler(EventHandler):
+class UpdateGameEventHandler(EventHandler[UpdateGameEvent]):
     def handle(self, event: "UpdateGameEvent", client_state: "ClientState") -> None:
         events = event.events
         game_event_pointer = client_state.profile.game_event_pointer
@@ -31,7 +31,7 @@ class UpdateGameEventHandler(EventHandler):
         ProcessServerEvents(client_state.profile, client_state.queue, events).execute()
 
 
-class RefreshGameStatusEventHandler(EventHandler):
+class RefreshGameStatusEventHandler(EventHandler[RefreshGameStatusEvent]):
     def handle(
         self, event: "RefreshGameStatusEvent", client_state: "ClientState"
     ) -> None:
@@ -40,7 +40,9 @@ class RefreshGameStatusEventHandler(EventHandler):
         ).execute()
 
 
-class RefreshGameStatusNetworkRequestEventHandler(EventHandler):
+class RefreshGameStatusNetworkRequestEventHandler(
+    EventHandler[RefreshGameStatusNetworkRequestEvent]
+):
     def handle(
         self, event: "RefreshGameStatusNetworkRequestEvent", client_state: "ClientState"
     ) -> None:
@@ -67,7 +69,7 @@ class RefreshGameStatusNetworkRequestEventHandler(EventHandler):
         return GetGameStatus(game_id, pointer, profile_id)
 
 
-handlers_map: Dict[Type["Event"], Type[EventHandler]] = {
+handlers_map: Dict[Type[E], Type[EventHandler[E]]] = {
     UpdateGameEvent: UpdateGameEventHandler,
     RefreshGameStatusEvent: RefreshGameStatusEventHandler,
     RefreshGameStatusNetworkRequestEvent: RefreshGameStatusNetworkRequestEventHandler,

--- a/client/engine/features/synchronization/event_handler.py
+++ b/client/engine/features/synchronization/event_handler.py
@@ -69,7 +69,7 @@ class RefreshGameStatusNetworkRequestEventHandler(
         return GetGameStatus(game_id, pointer, profile_id)
 
 
-handlers_map: Dict[Type[E], Type[EventHandler[E]]] = {
+handlers_map: Dict[Type["Event"], Type[EventHandler["Event"]]] = {
     UpdateGameEvent: UpdateGameEventHandler,
     RefreshGameStatusEvent: RefreshGameStatusEventHandler,
     RefreshGameStatusNetworkRequestEvent: RefreshGameStatusNetworkRequestEventHandler,

--- a/client/engine/primitives/event_handler.py
+++ b/client/engine/primitives/event_handler.py
@@ -1,4 +1,4 @@
-from abc import ABC
+from abc import ABC, abstractmethod
 from typing import TYPE_CHECKING, Generic, TypeVar
 
 if TYPE_CHECKING:
@@ -10,5 +10,6 @@ E = TypeVar("E", bound="Event")
 
 
 class EventHandler(Generic[E], ABC):
+    @abstractmethod
     def handle(self, event: E, client_state: "ClientState") -> None:
         pass

--- a/client/engine/primitives/event_handler.py
+++ b/client/engine/primitives/event_handler.py
@@ -1,11 +1,14 @@
 from abc import ABC
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Generic, TypeVar
 
 if TYPE_CHECKING:
     from client.engine.general_state.client_state import ClientState
     from client.engine.primitives.event import Event
 
 
-class EventHandler(ABC):
-    def handle(self, event: "Event", client_state: "ClientState") -> None:
+E = TypeVar("E", bound="Event")
+
+
+class EventHandler(Generic[E], ABC):
+    def handle(self, event: E, client_state: "ClientState") -> None:
         pass

--- a/client/experiment/event_handler.py
+++ b/client/experiment/event_handler.py
@@ -15,7 +15,7 @@ They do the actual procssing and can execute commands.
 """
 
 
-class ScreenTransitionEventHandler(BaseEventHandler):
+class ScreenTransitionEventHandler(BaseEventHandler[ScreenTransitionEvent]):
     def handle(self, event: ScreenTransitionEvent, client_state: "ClientState") -> None:
         # Could I just push the instances to the queue?
         if event.dest_screen == "main":
@@ -25,6 +25,6 @@ class ScreenTransitionEventHandler(BaseEventHandler):
 handlers_map = {ScreenTransitionEvent: ScreenTransitionEventHandler}
 
 
-class EventHandler(BaseEventHandler):
+class EventHandler(BaseEventHandler["Event"]):
     def handle(self, event: "Event", client_state: "ClientState") -> None:
         handlers_map[type(event)]().handle(event, client_state)

--- a/client/experiment/event_handler.py
+++ b/client/experiment/event_handler.py
@@ -1,4 +1,4 @@
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Any, Dict
 
 from client.engine.primitives.event_handler import EventHandler as BaseEventHandler
 

--- a/client/game/event_handler.py
+++ b/client/game/event_handler.py
@@ -34,7 +34,7 @@ They do the actual procssing and can execute commands.
 
 
 # ===== SERVER INGAME EVENTS COMMUNICATIONS ===== THIS ARE THE IN-GAME EVENTS PLACED BY THE SERVER
-class GameCreatedInGameEventHandler(BaseEventHandler):
+class GameCreatedInGameEventHandler(BaseEventHandler[GameCreatedInGameEvent]):
     def handle(
         self, event: GameCreatedInGameEvent, client_state: "ClientState"
     ) -> None:
@@ -43,7 +43,7 @@ class GameCreatedInGameEventHandler(BaseEventHandler):
         ).execute()
 
 
-class PlayerJoinedInGameEventHandler(BaseEventHandler):
+class PlayerJoinedInGameEventHandler(BaseEventHandler[PlayerJoinedInGameEvent]):
     def handle(
         self, event: PlayerJoinedInGameEvent, client_state: "ClientState"
     ) -> None:
@@ -52,7 +52,7 @@ class PlayerJoinedInGameEventHandler(BaseEventHandler):
         ).execute()
 
 
-class PlayerWinsInGameEventHandler(BaseEventHandler):
+class PlayerWinsInGameEventHandler(BaseEventHandler[PlayerWinsInGameEvent]):
     def handle(self, event: PlayerWinsInGameEvent, client_state: "ClientState") -> None:
         PlayerWinsInGameCommand(
             client_state.profile, client_state.queue, event.player_id
@@ -62,7 +62,7 @@ class PlayerWinsInGameEventHandler(BaseEventHandler):
 #################################################################
 
 
-class InitiateGameEventHandler(BaseEventHandler):
+class InitiateGameEventHandler(BaseEventHandler[InitiateGameEvent]):
     def handle(self, event: InitiateGameEvent, client_state: "ClientState") -> None:
         # TODO: Why is it not an screen transition event??? Just because it contains more data?
         client_state.set_current_screen(
@@ -76,7 +76,7 @@ class InitiateGameEventHandler(BaseEventHandler):
         )
 
 
-class ScreenTransitionEventHandler(BaseEventHandler):
+class ScreenTransitionEventHandler(BaseEventHandler[ScreenTransitionEvent]):
     def handle(self, event: ScreenTransitionEvent, client_state: "ClientState") -> None:
         # Could I just push the instances to the queue?
         if event.dest_screen == "intro":
@@ -99,7 +99,9 @@ class ScreenTransitionEventHandler(BaseEventHandler):
             client_state.set_current_screen(Profiles(client_state))
 
 
-class ClearInternalGameInformationEventHandler(BaseEventHandler):
+class ClearInternalGameInformationEventHandler(
+    BaseEventHandler[ClearInternalGameInformationEvent]
+):
     def handle(
         self, event: ClearInternalGameInformationEvent, client_state: "ClientState"
     ) -> None:
@@ -118,6 +120,6 @@ handlers_map = {
 }
 
 
-class EventHandler(BaseEventHandler):
+class EventHandler(BaseEventHandler["Event"]):
     def handle(self, event: "Event", client_state: "ClientState") -> None:
         handlers_map[type(event)]().handle(event, client_state)


### PR DESCRIPTION
Use generics to avoid #34 

By changing the definition of the base `EventHandler` class to:

```python

E = TypeVar("E", bound="Event")


class EventHandler(Generic[E], ABC):
    @abstractmethod
    def handle(self, event: E, client_state: "ClientState") -> None:
```

I can now specify that some event handlers that inherit form the base event handler receive not instances of event, but instances of specific events like:

```python
class QuitGameEventHandler(BaseEventHandler[QuitGameEvent]):
    def handle(self, event: "QuitGameEvent", client_state: 
```
without having typing errors.

I just had to remove the typing of the `handlers_maps` dictionaries used to join together this specific events with their handlers, I couldn't type that properly without errors so I just removed those types.

Nothing that I think changes the code much, but at list ends the mypy errors and fixes #34 